### PR TITLE
Terraform: Server 모듈 loginkey 이름 변경

### DIFF
--- a/infra/NCP/modules/server/main.tf
+++ b/infra/NCP/modules/server/main.tf
@@ -20,7 +20,7 @@ data "ncloud_vpc" "vpc" {
 }
 
 resource "ncloud_login_key" "loginkey" {
-  key_name = "${var.name}-key-${var.env}"
+  key_name = "${var.name}-loginkey-${var.env}"
 }
 
 resource "ncloud_access_control_group" "acg" {


### PR DESCRIPTION
- Terraform Error로 인한 loginkey 이름 변경